### PR TITLE
Added `run_with_coverage` method to `Sandbox`

### DIFF
--- a/example/hello_world.py
+++ b/example/hello_world.py
@@ -34,13 +34,13 @@ initial = houston.state.State({
 mission = houston.mission.Mission(environment, initial, actions)
 
 # create a container for the mission execution
-#sandbox = sut.provision()
-#res = sandbox.run(mission)
-#print(res)
+sandbox = sut.provision()
+(res, coverage) = sandbox.run_with_coverage(mission)
+print(coverage)
 
-mission_generator = RandomMissionGenerator(sut, initial, environment)
-resource_limits = ResourceLimits(2, 1000)
-mission_generator.generate(100, resource_limits)
+# mission_generator = RandomMissionGenerator(sut, initial, environment)
+# resource_limits = ResourceLimits(2, 1000)
+# mission_generator.generate(100, resource_limits)
 #mission_generator.prepare(100, resource_limits)
 #for i in range(5):
 #    m = mission_generator.generate_mission()

--- a/houston/sandbox.py
+++ b/houston/sandbox.py
@@ -75,7 +75,7 @@ class Sandbox(object):
         extractor = language.coverage_extractor
         extractor._prepare(self.bugzoo)
         outcome = self.run(mission)
-        coverage = extractor._extract()
+        coverage = extractor._extract(self.bugzoo)
         return (outcome, coverage)
 
     def run(self, mission: Mission) -> MissionOutcome:

--- a/houston/sandbox.py
+++ b/houston/sandbox.py
@@ -9,6 +9,7 @@ from houston.state import State
 from houston.mission import Mission, MissionOutcome
 from houston.util import TimeoutError, printflush
 from houston.action import ActionOutcome
+from bugzoo.coverage.base import FileLineCoverage
 
 
 class Sandbox(object):
@@ -54,6 +55,27 @@ class Sandbox(object):
         Stops the SITL running inside this sandbox.
         """
         raise NotImplementedError
+
+    def run_with_coverage(self,
+                          mission: Mission
+                          ) -> Tuple[MissionOutcome, Dict[str, LineCoverage]]:
+        """
+        Executes a given mission and returns detailed coverage information.
+
+        Returns:
+            A tuple of the form `(outcome, coverage)`, where `outcome` provides
+            a concise description of the outcome of the mission execution, and
+            `coverage` specifies the lines that were covered during the
+            execution for each source code file belonging to the system under
+            test.
+        """
+        # TODO: somewhat hardcoded
+        language = self.bugzoo.bug.languages[0]
+        extractor = language.coverage_extractor
+        extractor._prepare(self.bugzoo)
+        outcome = self.run(mission)
+        coverage = extractor._extract()
+        return (outcome, coverage)
 
     def run(self, mission: Mission) -> MissionOutcome:
         """

--- a/houston/sandbox.py
+++ b/houston/sandbox.py
@@ -4,7 +4,7 @@ import signal
 import time
 import threading
 from timeit import default_timer as timer
-from typing import Optional
+from typing import Optional, Tuple, Dict
 from houston.state import State
 from houston.mission import Mission, MissionOutcome
 from houston.util import TimeoutError, printflush
@@ -58,7 +58,8 @@ class Sandbox(object):
 
     def run_with_coverage(self,
                           mission: Mission
-                          ) -> Tuple[MissionOutcome, Dict[str, LineCoverage]]:
+                          ) -> Tuple[MissionOutcome,
+                                     Dict[str, FileLineCoverage]]:
         """
         Executes a given mission and returns detailed coverage information.
 


### PR DESCRIPTION
The code in this function *should* work, but ArduPilot is not producing coverage information inside the container (i.e., `gcov` isn't working). To go forward, we first need to debug the Docker container to get ArduPilot to produce coverage. Once that's working, we should test the integration.