### PR TITLE
Template-based mission generator (fixes #259)

### DIFF
--- a/experiments/generate_missions.py
+++ b/experiments/generate_missions.py
@@ -45,7 +45,7 @@ def generate(num_missions: int,
     config = build_config(speedup)
     mission_generator = RandomMissionGenerator(sut, initial, environment, config, max_num_commands=max_num_commands)
     resource_limits = ResourceLimits(num_missions)
-    missions = mission_generator.generate(None, resource_limits)
+    missions = mission_generator.generate(seed, resource_limits)
     with open(output_file, "w") as f:
         mission_descriptions = list(map(Mission.to_dict, missions))
         json.dump(mission_descriptions, f, indent=2)

--- a/experiments/generate_missions_templatebased.py
+++ b/experiments/generate_missions_templatebased.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import yaml
 import logging
 import argparse
 import random
@@ -11,9 +12,13 @@ from houston.generator.resources import ResourceLimits
 from settings import sut, initial, environment, build_config
 
 
-def setup_logging() -> None:
+logger = logging.getLogger("houston")  # type: logging.Logger
+logger.setLevel(logging.DEBUG)
+
+
+def setup_logging(verbose: bool = False) -> None:
     log_to_stdout = logging.StreamHandler()
-    log_to_stdout.setLevel(logging.DEBUG)
+    log_to_stdout.setLevel(logging.DEBUG if verbose else logging.INFO)
     logging.getLogger('houston').addHandler(log_to_stdout)
 
 
@@ -23,8 +28,10 @@ def parse_args():
                        help='number of missions to be generated.')
     parser.add_argument('max_num_commands', type=int, action='store',
                         help='maximum number of commands in a single mission.')
-    parser.add_argument('template', type=str, action='store',
+    parser.add_argument('-t', type=str, action='store',
                         help='template of the mission.')
+    parser.add_argument('-f', type=str, action='store',
+                        help='yaml file of mutants nad their templates.')
     parser.add_argument('--speedup', action='store', type=int,
                         default=1,
                         help='simulation speedup that should be used')
@@ -34,33 +41,70 @@ def parse_args():
     parser.add_argument('--output', action='store', type=str,
                         default='missions.json',
                         help='the file where the results will be stored')
+    parser.add_argument('--verbose', action='store_true',
+                        default=False,
+                        help='verbose logging.')
     return parser.parse_args()
 
 
 def generate(num_missions: int,
              max_num_commands: int,
              seed: int,
-             output_file: str,
              speedup: int,
              template: str
              ) -> None:
-    random.seed(seed)
     config = build_config(speedup)
     mission_generator = TemplateBasedMissionGenerator(sut, initial, environment, config, max_num_commands=max_num_commands)
     resource_limits = ResourceLimits(num_missions)
     missions = mission_generator.generate(seed, resource_limits,
                 template=template)
-    with open(output_file, "w") as f:
-        mission_descriptions = list(map(Mission.to_dict, missions))
-        json.dump(mission_descriptions, f, indent=2)
+    return missions
+
 
 
 if __name__ == "__main__":
-    setup_logging()
     args = parse_args()
-    generate(num_missions=args.number_of_mission,
-             max_num_commands=args.max_num_commands,
-             seed=args.seed,
-             output_file=args.output,
-             speedup=args.speedup,
-             template=args.template)
+    setup_logging(args.verbose)
+    random.seed(args.seed)
+    with open(args.output, "w") as f:
+        pass
+    if args.t:
+        missions = generate(num_missions=args.number_of_mission,
+                 max_num_commands=args.max_num_commands,
+                 seed=args.seed,
+                 speedup=args.speedup,
+                 template=args.t)
+    elif args.f:
+        templates = []
+        with open(args.f, "r") as f:
+            mutants = yaml.load(f, Loader=yaml.FullLoader)
+            for m in mutants:
+                template = m.get('mission-template')
+                if not template:
+                    continue
+                if isinstance(template, str):
+                    templates.append((template, args.number_of_mission))
+                elif isinstance(template, list):
+                    n_missions = args.number_of_mission
+                    for i, t in enumerate(template):
+                        if i == len(template)-1:
+                            templates.append((t, n_missions))
+                        else:
+                            r = random.randint(0, n_missions)
+                            templates.append((t, r))
+                            n_missions -= r
+        logger.info("Number of templates: %d", len(templates))
+        logger.info("AAAA %s", templates)
+        missions = []
+        for template, num in templates:
+            missions.extend(generate(num_missions=num,
+                     max_num_commands=args.max_num_commands,
+                     seed=args.seed,
+                     speedup=args.speedup,
+                     template=template))
+    else:
+        raise Exception("Provide either -t or -f")
+
+    with open(args.output, "w") as f:
+        mission_descriptions = list(map(Mission.to_dict, missions))
+        json.dump(mission_descriptions, f, indent=2)

--- a/experiments/generate_missions_templatebased.py
+++ b/experiments/generate_missions_templatebased.py
@@ -23,6 +23,8 @@ def parse_args():
                        help='number of missions to be generated.')
     parser.add_argument('max_num_commands', type=int, action='store',
                         help='maximum number of commands in a single mission.')
+    parser.add_argument('template', type=str, action='store',
+                        help='template of the mission.')
     parser.add_argument('--speedup', action='store', type=int,
                         default=1,
                         help='simulation speedup that should be used')
@@ -39,14 +41,15 @@ def generate(num_missions: int,
              max_num_commands: int,
              seed: int,
              output_file: str,
-             speedup: int
+             speedup: int,
+             template: str
              ) -> None:
     random.seed(seed)
     config = build_config(speedup)
     mission_generator = TemplateBasedMissionGenerator(sut, initial, environment, config, max_num_commands=max_num_commands)
     resource_limits = ResourceLimits(num_missions)
     missions = mission_generator.generate(seed, resource_limits,
-                template='TAKEOFF(alt:5.2)-.^*-LAND^2-.^1')
+                template=template)
     with open(output_file, "w") as f:
         mission_descriptions = list(map(Mission.to_dict, missions))
         json.dump(mission_descriptions, f, indent=2)
@@ -59,4 +62,5 @@ if __name__ == "__main__":
              max_num_commands=args.max_num_commands,
              seed=args.seed,
              output_file=args.output,
-             speedup=args.speedup)
+             speedup=args.speedup,
+             template=args.template)

--- a/experiments/generate_missions_templatebased.py
+++ b/experiments/generate_missions_templatebased.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import json
+import logging
+import argparse
+import random
+
+from houston.mission import Mission
+from houston.generator.template_based import TemplateBasedMissionGenerator
+from houston.generator.resources import ResourceLimits
+
+from settings import sut, initial, environment, build_config
+
+
+def setup_logging() -> None:
+    log_to_stdout = logging.StreamHandler()
+    log_to_stdout.setLevel(logging.DEBUG)
+    logging.getLogger('houston').addHandler(log_to_stdout)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Generates missions')
+    parser.add_argument('number_of_mission', type=int, action='store',
+                       help='number of missions to be generated.')
+    parser.add_argument('max_num_commands', type=int, action='store',
+                        help='maximum number of commands in a single mission.')
+    parser.add_argument('--speedup', action='store', type=int,
+                        default=1,
+                        help='simulation speedup that should be used')
+    parser.add_argument('--seed', action='store', type=int,
+                        default=1000,
+                        help='random seed to be used by random generator.')
+    parser.add_argument('--output', action='store', type=str,
+                        default='missions.json',
+                        help='the file where the results will be stored')
+    return parser.parse_args()
+
+
+def generate(num_missions: int,
+             max_num_commands: int,
+             seed: int,
+             output_file: str,
+             speedup: int
+             ) -> None:
+    random.seed(seed)
+    config = build_config(speedup)
+    mission_generator = TemplateBasedMissionGenerator(sut, initial, environment, config, max_num_commands=max_num_commands)
+    resource_limits = ResourceLimits(num_missions)
+    missions = mission_generator.generate(seed, resource_limits,
+                template='TAKEOFF(alt:5.2)-.^*-LAND^2-.^1')
+    with open(output_file, "w") as f:
+        mission_descriptions = list(map(Mission.to_dict, missions))
+        json.dump(mission_descriptions, f, indent=2)
+
+
+if __name__ == "__main__":
+    setup_logging()
+    args = parse_args()
+    generate(num_missions=args.number_of_mission,
+             max_num_commands=args.max_num_commands,
+             seed=args.seed,
+             output_file=args.output,
+             speedup=args.speedup)

--- a/experiments/generate_missions_templatebased.py
+++ b/experiments/generate_missions_templatebased.py
@@ -74,6 +74,7 @@ if __name__ == "__main__":
                  seed=args.seed,
                  speedup=args.speedup,
                  template=args.t)
+        mission_descriptions = list(map(Mission.to_dict, missions))
     elif args.f:
         templates = []
         with open(args.f, "r") as f:
@@ -83,28 +84,32 @@ if __name__ == "__main__":
                 if not template:
                     continue
                 if isinstance(template, str):
-                    templates.append((template, args.number_of_mission))
+                    templates.append((template, args.number_of_mission, m['uid']))
                 elif isinstance(template, list):
                     n_missions = args.number_of_mission
                     for i, t in enumerate(template):
                         if i == len(template)-1:
-                            templates.append((t, n_missions))
+                            templates.append((t, n_missions, m['uid']))
                         else:
                             r = random.randint(0, n_missions)
-                            templates.append((t, r))
+                            templates.append((t, r, m['uid']))
                             n_missions -= r
         logger.info("Number of templates: %d", len(templates))
         logger.info("AAAA %s", templates)
-        missions = []
-        for template, num in templates:
-            missions.extend(generate(num_missions=num,
+        mission_descriptions = []
+        for template, num, uid in templates:
+            missions = generate(num_missions=num,
                      max_num_commands=args.max_num_commands,
                      seed=args.seed,
                      speedup=args.speedup,
-                     template=template))
+                     template=template)
+            for n in missions:
+                new_dict = n.to_dict()
+                new_dict['mutant'] = uid
+                mission_descriptions.append(new_dict)
     else:
         raise Exception("Provide either -t or -f")
 
+    logger.info("Total number of missions: %d", len(mission_descriptions))
     with open(args.output, "w") as f:
-        mission_descriptions = list(map(Mission.to_dict, missions))
         json.dump(mission_descriptions, f, indent=2)

--- a/houston/ardu/command_factory.py
+++ b/houston/ardu/command_factory.py
@@ -27,8 +27,12 @@ def circle_based_generator(cls: Type[Command],
     destination = dist.destination(origin, heading)
 
     prob_zero = 0.1  # the probability of generating 0.0 as the parameter value
-    params['lat'] = destination.latitude if rng.random() >= prob_zero else 0.0
-    params['lon'] = destination.longitude if rng.random() >= prob_zero else 0.0
+    if rng.random() >= prob_zero:
+        params['lat'] = destination.latitude
+        params['lon'] = destination.longitude
+    else:
+        params['lat'] = 0.0
+        params['lon'] = 0.0
 
     command = cls(**params)
     return command

--- a/houston/command.py
+++ b/houston/command.py
@@ -372,6 +372,19 @@ class Command(object, metaclass=CommandMeta):
         command = cls(**params)
         return command
 
+    @classmethod
+    def generate_fixed_params(cls,
+                              fixed_params: Dict[str, Any],
+                              rng: random.Random
+                              ) -> 'Command':
+        params = {}
+        for p in cls.parameters:
+            if p.name in fixed_params.keys():
+                params[p.name] = fixed_params[p.name]
+            else:
+                params[p.name] = p.generate(rng)
+        command = cls(**params)
+        return command
 
 @attr.s(frozen=True)
 class CommandOutcome(object):

--- a/houston/command.py
+++ b/houston/command.py
@@ -377,12 +377,13 @@ class Command(object, metaclass=CommandMeta):
                               fixed_params: Dict[str, Any],
                               rng: random.Random
                               ) -> 'Command':
+        new_cmd = cls.generate(rng)
         params = {}
-        for p in cls.parameters:
+        for p in new_cmd:
             if p.name in fixed_params.keys():
                 params[p.name] = fixed_params[p.name]
             else:
-                params[p.name] = p.generate(rng)
+                params[p.name] = new_cmd[p.name]
         command = cls(**params)
         return command
 

--- a/houston/command.py
+++ b/houston/command.py
@@ -386,6 +386,7 @@ class Command(object, metaclass=CommandMeta):
         command = cls(**params)
         return command
 
+
 @attr.s(frozen=True)
 class CommandOutcome(object):
     """

--- a/houston/generator/base.py
+++ b/houston/generator/base.py
@@ -29,7 +29,7 @@ class MissionGeneratorStream(object):
         """
         return self
 
-    def __next__(self):
+    def __next__(self, **kwargs):
         """
         Requests the next mission from the mission generator.
         """
@@ -38,7 +38,7 @@ class MissionGeneratorStream(object):
             g.tick()
             if g.exhausted():
                 raise StopIteration
-            mission = self.__generator.generate_mission()
+            mission = self.__generator.generate_mission(**kwargs)
             g.tick()
             g.resource_usage.num_missions += 1
             mission_num = g.resource_usage.num_missions
@@ -205,7 +205,8 @@ class MissionGenerator(object):
 
     def generate(self,
                  seed: int,
-                 resource_limits: ResourceLimits
+                 resource_limits: ResourceLimits,
+                 **kwargs
                  ) -> List[Mission]:
         """
         Generate missions and return them
@@ -219,7 +220,7 @@ class MissionGenerator(object):
             self.tick()
             # TODO use threads
             while True:
-                mission = stream.__next__()
+                mission = stream.__next__(**kwargs)
                 missions.append(mission)
         except StopIteration:
             logger.info("Done with generating missions")

--- a/houston/generator/template_based.py
+++ b/houston/generator/template_based.py
@@ -31,7 +31,7 @@ class CommandTemplate:
 
     @staticmethod
     def from_str(template_str: str) -> 'CommandTemplate':
-        regex = "(?P<cmd>[a-zA-Z\.\_]+)(?P<params>\(.*\))?(?P<repeats>\^[\d\*]*)?"
+        regex = r"(?P<cmd>[a-zA-Z\.\_]+)(?P<params>\(.*\))?(?P<repeats>\^[\d\*]*)?"  # noqa: pycodestyle
         matched = re.fullmatch(regex, template_str.strip())
         if not matched:
             logger.error("Template is wrong %s", template_str)
@@ -104,12 +104,12 @@ class TemplateBasedMissionGenerator(MissionGenerator):
         return g(self.rng)
 
     def generate_mission(self, template: str):
-        command_templates = [CommandTemplate.from_str(t) \
-            for t in template.split("-")]
+        command_templates = [CommandTemplate.from_str(t)
+                             for t in template.split("-")]
         logger.info("COMMANDS: %s", command_templates)
         cmds_len = self.max_num_commands
-        cmds_len -= sum([c.repeats for c in command_templates \
-            if c.repeats > 0])
+        cmds_len -= sum([c.repeats for c in command_templates
+                         if c.repeats > 0])
         command_classes = list(self.system.commands.values())
         for tries in range(50):
             commands = []
@@ -117,17 +117,18 @@ class TemplateBasedMissionGenerator(MissionGenerator):
             try:
                 for ct in command_templates:
                     r = ct.repeats
-                    if r <=0:
+                    if r <= 0:
                         r = self.rng.randint(0, max_nonfixed_commands)
                     for i in range(r):
                         if commands:
                             next_allowed = commands[-1].__class__.get_next_allowed(self.system)  # noqa: pycodestyle
                         else:
-                            next_allowed = [cc for cc in command_classes] # Everything is allowed
+                            # everything is allowed
+                            next_allowed = [cc for cc in command_classes]
 
                         if ct.cmd != '.':
-                            next_allowed = [cc for cc in next_allowed \
-                                if ct.cmd in cc.uid]
+                            next_allowed = [cc for cc in next_allowed
+                                            if ct.cmd in cc.uid]
 
                         if not next_allowed:
                             if ct.repeats > 0:
@@ -138,7 +139,8 @@ class TemplateBasedMissionGenerator(MissionGenerator):
                                 break
                         params = ct.params or {}
                         command_class = self.rng.choice(next_allowed)
-                        commands.append(self.generate_command(command_class, params))
+                        commands.append(self.generate_command(command_class,
+                                                              params))
                         if ct.repeats <= 0:
                             max_nonfixed_commands -= 1
                 break

--- a/houston/generator/template_based.py
+++ b/houston/generator/template_based.py
@@ -124,15 +124,21 @@ class TemplateBasedMissionGenerator(MissionGenerator):
                             next_allowed = [cc for cc in next_allowed \
                                 if ct.cmd in cc.uid]
 
-                        if not next_allowed and ct.repeats > 0:
-                            logger.debug("So far %s", commands)
-                            raise FailedMissionGenerationException
+                        if not next_allowed:
+                            if ct.repeats > 0:
+                                logger.debug("So far %s", commands)
+                                commands = []
+                                raise FailedMissionGenerationException
+                            else:
+                                break
                         command_class = self.rng.choice(next_allowed)
                         commands.append(self.generate_command(command_class))
                 break
             except FailedMissionGenerationException:
                 logger.debug("Try %d failed", tries)
                 continue
+        if not commands:
+            raise FailedMissionGenerationException("Mission generation failed")
         logger.info("Generated mission: %s", commands)
         raise Exception
         return Mission(self.__configuration,

--- a/houston/generator/template_based.py
+++ b/houston/generator/template_based.py
@@ -184,7 +184,7 @@ class TemplateBasedMissionGenerator(MissionGenerator):
                 continue
         if not commands:
             raise FailedMissionGenerationException("Mission generation failed")
-        logger.info("Generated mission: %s", commands)
+        logger.debug("Generated mission: %s", commands)
         return Mission(self.__configuration,
                        self.__env,
                        self.__initial_state,

--- a/houston/generator/template_based.py
+++ b/houston/generator/template_based.py
@@ -1,0 +1,120 @@
+from typing import Type, Dict, Callable, Optional, Any
+import logging
+import attr
+import re
+
+from .base import MissionGenerator
+from ..mission import Mission
+from ..system import System
+from ..state import State
+from ..environment import Environment
+from ..configuration import Configuration
+from ..command import Command
+
+logger = logging.getLogger(__name__)   # type: logging.Logger
+logger.setLevel(logging.DEBUG)
+
+
+@attr.s
+class CommandTemplate:
+    cmd = attr.ib(type=str)
+    repeats = attr.ib(type=int)
+    params = attr.ib(type=Optional[Dict[str, Any]], default=None)
+
+    @staticmethod
+    def from_str(template_str: str) -> 'CommandTemplate':
+        regex = "(?P<cmd>[a-zA-Z\.]+)(?P<params>\(.*\))?(?P<repeats>\^[\d\*]*)?"
+        matched = re.fullmatch(regex, template_str.strip())
+        if not matched:
+            logger.error("Template is wrong %s", template_str)
+            return None
+        groups = matched.groupdict()
+        cmd = groups['cmd']
+        params = None
+        repeats = 1
+        if groups['params']:
+            pairs = groups['params'].strip()[1:-1].split(",")
+            params = {}
+            for pair in pairs:
+                splited = pair.split(":")
+                assert len(splited) == 2
+                params[splited[0].strip()] = eval(splited[1])
+        if groups['repeats']:
+            r = groups['repeats'][1:].strip()
+            if r == '*':
+                repeats = -1
+            else:
+                repeats = int(r)
+        return CommandTemplate(cmd, repeats, params)
+
+    def __str__(self):
+        s = "cmd: {}, params:{}, repeats: {}"
+        return s.format(self.cmd,
+                        self.params,
+                        self.repeats)
+
+
+class TemplateBasedMissionGenerator(MissionGenerator):
+    def __init__(self,
+                 system: Type[System],
+                 initial_state: State,
+                 env: Environment,
+                 config: Configuration,
+                 threads: int = 1,
+                 command_generators: Optional[Dict[str, Callable]] = None,
+                 max_num_commands: int = 10
+                 ) -> None:
+        super().__init__(system, threads, command_generators, max_num_commands)
+        self.__initial_state = initial_state
+        self.__env = env
+        self.__configuration = config
+
+    @property
+    def initial_state(self):
+        """
+        The initial state used by all missions produced by this generator.
+        """
+        return self.__initial_state
+
+    @property
+    def env(self):
+        """
+        The environment used by all missions produced by this generator.
+        """
+        return self.__env
+
+    def generate_command(self, command_class: Type[Command]) -> Command:
+        generator = self.command_generator(command_class)
+        if generator is None:
+            return command_class.generate(self.rng)
+        # g = generator.generate_action_without_state
+        # return g(self.system, self.__env, self.rng)
+        return g(self.rng)
+
+    def generate_mission(self, template: str):
+        command_templates = [CommandTemplate.from_str(t) \
+            for t in template.split("-")]
+        logger.info("COMMANDS: %s", command_templates)
+        raise Exception
+        command_classes = list(self.system.commands.values())
+        takeoff = None
+        for c in command_classes:
+            if "MAV_CMD_NAV_TAKEOFF" in c.uid:
+                takeoff = c
+                break
+        if not takeoff:
+            raise Exception("No TAKEOFF command found")
+        commands = [self.generate_command(takeoff)]
+        cmds_len = self.max_num_commands
+        for i in range(1, cmds_len):
+            next_allowed = commands[i - 1].__class__.get_next_allowed(self.system)  # noqa: pycodestyle
+            if next_allowed:
+                command_class = self.rng.choice(next_allowed)
+                commands.append(self.generate_command(command_class))
+            else:
+                break
+        return Mission(self.__configuration,
+                       self.__env,
+                       self.__initial_state,
+                       commands,
+                       self.system)


### PR DESCRIPTION
Generates missions based on provided template. The template is provided as a `str` which is a list of command templates separated by `-`. A command template has the following format:
```
<COMMAND_NAME>(<FIXED PARAMETERS>)^<NUMBER OF REPEATS>
```
Example:
```
TAKEOFF(alt: 5.2)^2
```
Which represents two `TAKEOFF` commands with parameter `alt` set to 5.2.
Providing the parameters are optional. If not provided they will be generated by random.
Providing the number of repeats is optional. If not provided it will be set to 1. If set to `*` it means number of repeats could be determined dynamically and could be between 0 to maximum allowed.
If command name is set to `.` the template considers all possible commands.

A full template example:
```
TAKEOFF(alt:4.2)-.^*-LAND-.^1-LOITER(lon:0.0, lat:0.0)-.^*"
```
A single `TAKEOFF` command with parameter `alt` set to 4.2 is followed by 0 or more commands, followed by a single `LAND` command (with random parameters), followed by a single command (picked randomly from all possible commands), followed by a single `LOITER` command with two fixed parameters, and finally followed by 0 or more random commands.